### PR TITLE
Comment out default email IDs for UIN sending

### DIFF
--- a/print-default.properties
+++ b/print-default.properties
@@ -134,7 +134,7 @@ token.request.issuerUrl=${keycloak.internal.url}/auth/realms/mosip
 
 ##-----Kernel Service URL for Sending Emails---#
 mosip.send.uin.email.attachment.enabled=true
-mosip.send.uin.default-emailIds=tf.mosip.demo@gmail.com
+# mosip.send.uin.default-emailIds=tf.mosip.demo@gmail.com
 emailResource.url=http://notifier.kernel/v1/notifier/email/send
 mosip.utc-datetime-pattern=yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 


### PR DESCRIPTION
Comment out the default email IDs in print-default.properties